### PR TITLE
add config for absolute imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,5 +30,10 @@
       }
     ],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+  },
+  "settings": {
+    "import/resolver": {
+      "node": { "moduleDirectory": ["node_modules", "src/"] }
+    }
   }
 }


### PR DESCRIPTION
closes #51 

We can not use both relative and absolute imports in the front end part